### PR TITLE
Add UI-focused summary of agent interface bible

### DIFF
--- a/Biblia Interfaz de Agentes - Resumen UI.md
+++ b/Biblia Interfaz de Agentes - Resumen UI.md
@@ -1,0 +1,85 @@
+# Biblia de la Interfaz de Agentes de IA: Resumen y Enfoque de UI
+
+Autor: Codex
+Estado: Borrador
+Tags: Biblia, Interfaz, UI, IA
+
+## 1. Propósito General
+
+La biblia de la Interfaz de Agentes de IA describe la plataforma **Violet Studio** cuyo objetivo es operar la arquitectura modular de agentes IA y las "Biblias vivas" de conocimiento. Establece que la plataforma debe convertir la huella digital de la organización en un activo vectorizable y trazable, empoderando a los usuarios tácticos y a los curadores para colaborar con agentes especializados.
+
+## 2. Principios de Ingeniería
+
+- **Modularidad Rol+Servicio**
+- **Conocimiento vectorizado** como activo central
+- **Curación humana** como filtro de calidad
+- **Usabilidad dual**: legible para humanos y procesable por máquinas
+
+(Ver líneas 41–85 del archivo original para la lista completa de principios.)
+
+## 3. Arquitectura General
+
+La biblia define componentes esenciales:
+
+- **Bases de conocimiento vectoriales** separadas por Rol+Servicio.
+- **Agentes IA especializados** que operan sobre dichas bases.
+- **Interfaz Central ("Libro Vivo")** donde los usuarios interactúan, editan y validan contenido.
+- **Sistemas de retroalimentación y versionado** para mantener la trazabilidad.
+
+(Referencias en líneas 91–267.)
+
+## 4. Flujo de Conocimiento
+
+El flujo comprende etapas de ingesta, curación, procesamiento para vectorización, vectorización, consulta de agentes, retroalimentación y generación de informes.
+
+(Ver sección 5, líneas 670–905.)
+
+## 5. Marco UX/UI
+
+La sección 6 del documento aborda de forma detallada la experiencia de usuario. Destaca los siguientes pilares:
+
+- Navegación contextual basada en Rol+Servicio.
+- Editor de texto enriquecido con guías para vectorizar.
+- Mecanismos de retroalimentación claros (✅, ❌, 🛠️).
+- Herramientas diferenciadas para usuarios tácticos y curadores.
+
+(Referencias en líneas 946–995.)
+
+### 5.1 Diseño de la Interfaz del "Libro Vivo"
+
+La biblia sugiere que la UI incluya:
+
+- Paneles de navegación y visualización del contenido vectorizable.
+- Chat contextual para el Rol Táctico y otro para el Curador, permitiendo "Probatones" y validación del conocimiento.
+- Historial de versiones con resumen de cambios y motivos de edición.
+- Indicadores de estado (borrador, validación, etc.) y filtros para priorizar la curación.
+
+(Referencias en líneas 1016–1069.)
+
+### 5.2 UI para Versionado y Trazabilidad
+
+La UI debe exponer el historial de cambios, permitir comparar versiones y registrar el motivo de cada modificación. El diseño se inspira en patrones de herramientas como GitHub y Google Docs.
+
+(Ver líneas 1059–1067.)
+
+### 5.3 UI para "BibliaFlow"
+
+El modelo "BibliaFlow" adapta Gitflow a la gestión de contenido. La interfaz debe abstraer las ramas y fusiones en acciones como "Someter para Revisión" o "Aprobar Actualización". Puede incluir una vista de ramas de contribución para resolver conflictos.
+
+(Ver líneas 1143–1207.)
+
+## 6. Sistema de Diseño
+
+El documento recomienda crear un **Sistema de Diseño** para la plataforma, documentado como otra biblia. Herramientas como Figma, Storybook y Zeroheight son sugeridas para mantener componentes reutilizables y coherencia visual.
+
+(Referencias en líneas 1228–1249.)
+
+## 7. Definición de "Biblia"
+
+En Lexy, una "biblia" es un **documento maestro** que compila de forma estructurada todo el conocimiento de un rol o proceso. Se actualiza de forma continua y alimenta a los agentes de IA tras su vectorización.
+
+(Consultar `pasted_content.txt` líneas 1–24 para la explicación completa.)
+
+---
+
+Este resumen sintetiza los puntos clave de la **Biblia de la Interfaz de Agentes de IA**, haciendo énfasis en los lineamientos de diseño de la interfaz y la gestión de la experiencia de usuario.


### PR DESCRIPTION
## Summary
- create a concise biblia-style summary of the Interface de Agentes de IA
- highlight key UI/UX guidelines, versioning and BibliaFlow concepts

## Testing
- `pytest -q`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684211de449c8329b64c1fca59930b93